### PR TITLE
Allow using absolute paths in dirname options

### DIFF
--- a/lib/rack/sassc.rb
+++ b/lib/rack/sassc.rb
@@ -26,7 +26,7 @@ module Rack
     end
 
     def location dirname
-      ::File.join @opts[:public_location], dirname.to_s
+      ::File.expand_path @opts[:public_location], dirname.to_s
     end
 
     def filepath dirname, filename, ext


### PR DESCRIPTION
When `dirname` is an absolute path, it should not simply be appended to `public_location`.

My `scss_dirname` is not in `public_location`, and I suppose that's pretty common. Instead of configuring a relative path from `public_location` to the scss directory, I want to use an absolute path instead.

An alternative would be to remove `public_location` option altogether and only use `css_dirname` and `scss_dirname` separately. Actually, I'd probably prefer this, because usually, css and scss files are in completely separate trees and especially `scss` don't reside in a public folder.